### PR TITLE
Update composer.json Guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "php": ">=7.1",
         "ext-curl": "*",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^7.0.1",
+        "guzzlehttp/guzzle": "^7.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "php": ">=7.1",
         "ext-curl": "*",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^7.0.1",
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
To avoid this on a new Laravel 8 install:

    - evilfreelancer/bookeo-api-php[1.2.0, ..., 1.2.4] require guzzlehttp/guzzle ^6.0 -> found guzzlehttp/guzzle[6.0.0, ..., 6.5.x-dev] but it conflicts with your root composer.json require (^7.0.1).
